### PR TITLE
restart von "always" auf "unless-stopped"

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ services:
   ddns-ipv64:
     image: alcapone1933/ddns-ipv64:latest
     container_name: ddns-ipv64
-    restart: always
+    restart: unless-stopped
     environment:
       - "TZ=Europe/Berlin"
       - "CRON_TIME=*/15 * * * *"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,9 +4,9 @@ services:
     # build:
       # dockerfile: ./Dockerfile
     image: alcapone1933/ddns-ipv64:latest
-    # image: alcapone1933/ddns-ipv64:v0.1.4
+    # image: alcapone1933/ddns-ipv64:v0.1.4 / v0.1.5 
     container_name: ddns-ipv64
-    restart: always
+    restart: unless-stopped
     # volumes:
       # - data:/data
     environment:


### PR DESCRIPTION
"restart: " im "docker-compose.yml" geändert  auf "unless-stopped". Da mit "always", dass Problem gibt, das der Container konstant neu started. Und somit die Täglichen API update Tokken, in wenigen Stunden, verbraucht. Und somit denn container für den Rest des Tages unbrauhbar macht.